### PR TITLE
Fixes buyer's document type field name on order creation XML

### DIFF
--- a/lib/mundipagg/gateway.rb
+++ b/lib/mundipagg/gateway.rb
@@ -193,7 +193,7 @@ module Mundipagg
 				'mun:Name' => request.buyer.name,
 				'mun:PersonTypeEnum' => request.buyer.personTypeEnum,
 				'mun:TaxDocumentNumber' => request.buyer.taxDocumentNumber,
-				'mun:TaxDocumentNumberTypeEnum' => request.buyer.taxDocumentTypeEnum,
+				'mun:TaxDocumentTypeEnum' => request.buyer.taxDocumentTypeEnum,
 				'mun:TwitterId' => request.buyer.twitterId,
 				'mun:WorkPhone' => request.buyer.workPhone,
 				'mun:BuyerAddressCollection' => nil


### PR DESCRIPTION
Document Type field on order creation XML was mistyped as "mun:TaxDocumentNumberTypeEnum" instead of "mun:TaxDocumentTypeEnum", causing Mundipagg to create the order without the Document Type.